### PR TITLE
Added function to catch Sample packets and remove annoying warning

### DIFF
--- a/nodes/mtnode_new.py
+++ b/nodes/mtnode_new.py
@@ -436,6 +436,10 @@ class XSensDriver(object):
 				pass
 			# TODO RSSI
 
+		def fill_from_Sample(o):
+			'''Catch 'Sample' MTData blocks.'''
+			rospy.logdebug("Got MTi data packet: 'Sample', ignored!")
+
 		def find_handler_name(name):
 			return "fill_from_%s"%(name.replace(" ", "_"))
 


### PR DESCRIPTION
Added function to catch Sample packets and remove annoying warning in `mtnode_new.py`. I still kept the warning, but in debug logs.