### PR TITLE
add missing package dependency on python-serial

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
+  <run_depend>python-serial</run_depend>
 </package>
 
 


### PR DESCRIPTION
This commit enables to solve python package dependency with rosdep install.