### PR TITLE
Fix conversion from UTC to epoch time for /time_reference

### DIFF
--- a/nodes/mtnode.py
+++ b/nodes/mtnode.py
@@ -13,6 +13,7 @@ from geometry_msgs.msg import TwistStamped, PointStamped
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus
 import time
 import datetime
+import calendar
 
 # transform Euler angles or matrix into quaternions
 from math import radians, sqrt, atan2
@@ -392,7 +393,7 @@ class XSensDriver(object):
                 y, m, d, hr, mi, s, ns, f = o['Year'], o['Month'], o['Day'],\
                     o['Hour'], o['Minute'], o['Second'], o['ns'], o['Flags']
                 if f & 0x4:
-                    secs = time.mktime((y, m, d, hr, mi, s, 0, 0, 0))
+                    secs = calendar.timegm((y, m, d, hr, mi, s, 0, 0, 0))
                     publish_time_ref(secs, ns, 'UTC time')
             except KeyError:
                 pass

--- a/nodes/mtnode.py
+++ b/nodes/mtnode.py
@@ -223,9 +223,9 @@ class XSensDriver(object):
             start_of_week = stamp_day - datetime.timedelta(days=iso_day)
             # stamp at the millisecond precision
             stamp_ms = start_of_week + datetime.timedelta(milliseconds=itow)
-            secs = time.mktime((stamp_ms.year, stamp_ms.month, stamp_ms.day,
-                                stamp_ms.hour, stamp_ms.minute,
-                                stamp_ms.second, 0, 0, -1))
+            secs = calendar.timegm((stamp_ms.year, stamp_ms.month, stamp_ms.day,
+                                    stamp_ms.hour, stamp_ms.minute,
+                                    stamp_ms.second, 0, 0, -1))
             nsecs = stamp_ms.microsecond * 1000 + ns
             if nsecs < 0:  # ns can be negative
                 secs -= 1


### PR DESCRIPTION
Chasing some confusion with time syncing, I found what I think is a small bug in filling the /time_reference topic message from a UTC time.

The Xsens provides a UTC time stamp. To convert this to a ROS /time_reference (which I think is [defined](http://docs.ros.org/api/rospy/html/rospy.rostime.Time-class.html) as time since epoch), we should use [calendar.timegm()](https://docs.python.org/2/library/calendar.html#calendar.timegm) instead of [mktime()](https://docs.python.org/2/library/time.html#time.mktime) which expects a tuple in local time as its argument.