### PR TITLE
[WIP] Add ability to set synchronization settings via ROS node

### DIFF
--- a/nodes/mtnode.py
+++ b/nodes/mtnode.py
@@ -5,6 +5,7 @@ import select
 import sys
 
 import mtdevice
+from mtdevice import get_synchronization_settings
 import mtdef
 
 from std_msgs.msg import Header, String, UInt16
@@ -49,7 +50,7 @@ def matrix_from_diagonal(diagonal):
     return tuple(matrix)
 
 
-class XSensDriver(object):
+class XSensNode(object):
 
     def __init__(self):
         device = get_param('~device', 'auto')
@@ -74,6 +75,13 @@ class XSensDriver(object):
 
         rospy.loginfo("MT node interface: %s at %d bd." % (device, baudrate))
         self.mt = mtdevice.MTDevice(device, baudrate, timeout)
+
+        # Set sychronization settings
+        sync_settings = get_param('~synchronization', 'clear')
+        sync_settings = get_synchronization_settings(sync_settings)
+        print "Changing synchronization settings"
+        self.mt.SetSyncSettings(sync_settings)
+        print "Ok"  # should we test that it was actually ok?
 
         # optional no rotation procedure for internal calibration of biases
         # (only mark iv devices)
@@ -774,7 +782,7 @@ class XSensDriver(object):
 def main():
     '''Create a ROS node and instantiate the class.'''
     rospy.init_node('xsens_driver')
-    driver = XSensDriver()
+    driver = XSensNode()
     driver.spin()
 
 

--- a/nodes/mtnode.py
+++ b/nodes/mtnode.py
@@ -79,9 +79,8 @@ class XSensNode(object):
         # Set sychronization settings
         sync_settings = get_param('~synchronization', 'clear')
         sync_settings = get_synchronization_settings(sync_settings)
-        print "Changing synchronization settings"
-        self.mt.SetSyncSettings(sync_settings)
-        print "Ok"  # should we test that it was actually ok?
+        rospy.loginfo("Configuring Xsens IMU synchronization settings to " + str(sync_settings))
+        self.mt.SetSyncSettings([sync_settings])
 
         # optional no rotation procedure for internal calibration of biases
         # (only mark iv devices)


### PR DESCRIPTION
Currently, you need to call `mtdevice.py --synchronization=<settings>` in order to configure the IMU's sychronization settings. 

This PR does 2 things:
1. Allows the user to define the same synchronization settings in the ROS launch file, for example:

```
<node pkg="xsens_driver" type="mtnode.py" name="xsens_driver" output="screen" required="true">
  <param name="synchronization" value="0,0,0,0,0,0,0,0" />
</node>
```
It reuses the functions found in `mtdevice.py` to set the synchronization settings.

My motivation stems from the my requirement to synchronize the IMU and camera, there are many ways to do this, for my purpose I have chosen to trigger the camera via the IMU, in particular I'm trying to perform triggering using the "exposure-compensated" method as described in "[A Synchronized Visual-Inertial Sensor System with FPGA Pre-Processing for Accurate Real-Time SLAM](https://pdfs.semanticscholar.org/67a2/d0dbc24820f2e1ac49cd505111390b3d82a2.pdf)" by Nikolic et al. In ROS I suspect users will define their camera parameters such as exposure time in the launch files, having the ability to set both camera exposure time and change the IMU synchronization settings in the same launch file would be nice to have, this is what drove me to extend this functionality to the XSens ROS node.

2. Renames the `XSensDriver` class to `XsensNode` because this class is more of a ROS node than a driver per-se. The real driver is in `mtdevice.py`. Obviously this change is a bit superfluous, I'm willing to change it back if desired.