### PR TITLE
configure the output from the ros node launch

### DIFF
--- a/launch/xsens_driver.launch
+++ b/launch/xsens_driver.launch
@@ -4,6 +4,7 @@
     <arg name="baudrate" default="0" doc="baudrate of the IMU"/>
     <arg name="timeout" default="0.002" doc="timeout for the IMU communication"/>
     <arg name="initial_wait" default="0.1" doc="initial wait to allow device to come up"/>
+    <arg name="output_config" default="oq,ad,wd,mf" doc="OUTPUT format (as in mtdevice.py --help)"/>
     <arg name="frame_id" default="/imu" doc="frame id of the IMU"/>
     <arg name="frame_local" default="ENU" doc="desired frame orientation (ENU, NED or NWU)"/>
     <arg name="no_rotation_duration" default="0" doc="duration (int in seconds) of the no-rotation calibration procedure"/>
@@ -12,16 +13,17 @@
     <arg name="orientation_covariance_diagonal" default="[0.01745, 0.01745, 0.15708]" doc="Diagonal elements of the orientation covariance matrix"/>
 
     <!-- node -->
-	<node pkg="xsens_driver" type="mtnode.py" name="xsens_driver" output="screen" >
-		<param name="device" value="$(arg device)"/>
-		<param name="baudrate" value="$(arg baudrate)"/>
-		<param name="timeout" value="$(arg timeout)"/>
-		<param name="initial_wait" value="$(arg initial_wait)"/>
-		<param name="frame_id" value="$(arg frame_id)"/>
-		<param name="frame_local" value="$(arg frame_local)"/>
-		<param name="no_rotation_duration" value="$(arg no_rotation_duration)"/>
-		<rosparam param="angular_velocity_covariance_diagonal" subst_value="True">$(arg angular_velocity_covariance_diagonal)</rosparam>
-		<rosparam param="linear_acceleration_covariance_diagonal" subst_value="True">$(arg linear_acceleration_covariance_diagonal)</rosparam>
-		<rosparam param="orientation_covariance_diagonal" subst_value="True">$(arg orientation_covariance_diagonal)</rosparam>
-	</node>
+    <node pkg="xsens_driver" type="mtnode.py" name="xsens_driver" output="screen" >
+        <param name="device" value="$(arg device)"/>
+        <param name="baudrate" value="$(arg baudrate)"/>
+        <param name="timeout" value="$(arg timeout)"/>
+        <param name="initial_wait" value="$(arg initial_wait)"/>
+        <param name="output_config" value="$(arg output_config)" />
+        <param name="frame_id" value="$(arg frame_id)"/>
+        <param name="frame_local" value="$(arg frame_local)"/>
+        <param name="no_rotation_duration" value="$(arg no_rotation_duration)"/>
+        <rosparam param="angular_velocity_covariance_diagonal" subst_value="True">$(arg angular_velocity_covariance_diagonal)</rosparam>
+        <rosparam param="linear_acceleration_covariance_diagonal" subst_value="True">$(arg linear_acceleration_covariance_diagonal)</rosparam>
+        <rosparam param="orientation_covariance_diagonal" subst_value="True">$(arg orientation_covariance_diagonal)</rosparam>
+    </node>
 </launch>

--- a/nodes/mtnode.py
+++ b/nodes/mtnode.py
@@ -57,6 +57,7 @@ class XSensDriver(object):
         baudrate = get_param('~baudrate', 0)
         timeout = get_param('~timeout', 0.002)
         initial_wait = get_param('~initial_wait', 0.1)
+        output_config = get_param('~output_config', '')
         if device == 'auto':
             devs = mtdevice.find_devices(timeout=timeout,
                                          initial_wait=initial_wait)
@@ -79,6 +80,10 @@ class XSensDriver(object):
         rospy.loginfo("MT node interface: %s at %d bd." % (device, baudrate))
         self.mt = mtdevice.MTDevice(device, baudrate, timeout,
                                     initial_wait=initial_wait)
+        if output_config:
+            rospy.loginfo("Setting MTDevice OUTPUT to: '%s' " % output_config)
+            oc = mtdevice.get_output_config(output_config)
+            self.mt.SetOutputConfiguration(oc)
 
         # optional no rotation procedure for internal calibration of biases
         # (only mark iv devices)


### PR DESCRIPTION
I added one the missing configuration option in the ros-node launch. Removed tabs in that file. 

**feature**
being able to decide what output the sensor should publish (for example, mag.field + lin.accel.)

**before**
`python mtdevice.py --configure "ad,mg"`
`roslaunch xsens_driver xsens_driver.launch`

**after**
`roslaunch xsens_driver xsens_driver.launch`    // the .launch file including that config